### PR TITLE
feat(news): add UGA Research Annate feature

### DIFF
--- a/_posts/news/2026-04-02-uga-research-annate.md
+++ b/_posts/news/2026-04-02-uga-research-annate.md
@@ -1,0 +1,24 @@
+---
+layout: page
+title: "UGA Research Profiles Annate Bitherapeutics’ Mission to Help Future Cancer Patients"
+date: "2026-04-02"
+categories:
+  - press-release
+  - recognition
+tags:
+  - Annate Bitherapeutics
+  - University of Georgia
+  - multiple myeloma
+  - oncology
+  - cancer research
+  - Stephen Hajduk
+header: no
+teaser: "UGA Research spotlighted Annate Bitherapeutics in a feature on the personal story and scientific mission driving the company’s work to develop new cancer therapies."
+---
+
+The University of Georgia Research News recently published a compelling profile on Annate Bitherapeutics, highlighting the deeply personal mission driving the company's innovative work in cancer therapy. The article, titled "Love, loss, and a mission of hope for future cancer patients," delves into the story of co-founder Stephen Hajduk, whose personal experience with the loss of his wife, Ann Steadman, to multiple myeloma, became a powerful catalyst for Annate's efforts. <!--more-->
+
+The feature elaborates on Stephen and Ann's shared life, academic pursuits at UGA, and their journey together, emphasizing how Ann's battle with multiple myeloma profoundly shaped Stephen's dedication to developing new therapeutic approaches. Annate Bitherapeutics is a UGA startup focused on harnessing the body’s innate immune system to target and destroy cancer cells, aiming to bring hope to future cancer patients.
+
+Read the full story:
+[Love, loss, and a mission of hope for future cancer patients - UGA Research News](https://research.uga.edu/news/love-loss-and-a-mission-of-hope-for-future-cancer-patients/)


### PR DESCRIPTION
## Summary
- add a new newsroom post for Annate Bitherapeutics from UGA Research
- keep the change scoped to the relevant markdown file

## Source
- official source: https://research.uga.edu/news/love-loss-and-a-mission-of-hope-for-future-cancer-patients/

## Validation
- [x] Ran Jekyll build in the website mamba environment