### PR TITLE
feat(news): add Eric DeJesus Georgia Life Sciences CSBA Fly-In post

### DIFF
--- a/_posts/news/2026-04-21-gls-csba-fly-in.md
+++ b/_posts/news/2026-04-21-gls-csba-fly-in.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: "Eric DeJesus Joins Georgia Life Sciences in Washington for CSBA Fly-In"
+date: "2026-04-21"
+categories:
+- press-release
+- events
+- recognition
+tags:
+- Annate Bitherapeutics
+- Georgia Life Sciences
+- CSBA
+- Washington DC
+- Eric DeJesus
+- biotechnology policy
+header: no
+teaser: "Annate Bitherapeutics CEO Eric DeJesus, PhD, joined Georgia Life Sciences in Washington, DC, for the Council of State Bioscience Associations Fly-In to advocate for policies that support innovation, patients, and U.S. biotech leadership."
+---
+
+Annate Bitherapeutics is proud to share that **Eric DeJesus, PhD**, co-founder and CEO of Annate Bitherapeutics, joined **Georgia Life Sciences** in **Washington, DC** for the **Council of State Bioscience Associations (CSBA) Fly-In**. <!--more-->
+
+Georgia Life Sciences CEO **Maria Thacker Goethe** represented Georgia alongside **Evan Scullin, MD**, founder of LumeniSci, and **Eric DeJesus, PhD**, co-founder and CEO of Annate Bitherapeutics.
+
+During the visit, the group met with the offices of **Rep. Rick Allen**, **Rep. Buddy Carter**, **Rep. Mike Collins**, **Rep. Richard McCormick**, **Rep. Lucy McBath**, **Sen. Jon Ossoff**, and **Sen. Raphael Warnock** to discuss the importance of biotechnology to Georgia’s economy, patients, and future.
+
+According to Georgia Life Sciences, the delegation thanked Congress for reauthorizing **SBIR/STTR** and emphasized the importance of strong **NIH funding**, timely grantmaking, predictable policy, a modernized **FDA**, continued U.S. leadership in biotech, support for the **Congressional Biotech Caucus**, and biotechnology’s growing importance to national security.
+
+Reflecting on the experience, Dr. DeJesus said, “I learned so many wonderful lessons and left feeling significantly more confident about the direction our state is headed for the future of biotech!”
+
+Annate is grateful to Georgia Life Sciences for its leadership in advocating for the life sciences community and for the opportunity to help represent Georgia’s biotech sector in these important conversations.
+
+Read more:
+[Georgia Life Sciences on LinkedIn](https://www.linkedin.com/posts/georgialifesciences_biotechnology-lifesciences-nih-activity-7450957006598991873-haQ7)


### PR DESCRIPTION
## Summary
- add a newsroom post covering Eric DeJesus' participation in the CSBA Fly-In with Georgia Life Sciences in Washington, DC
- keep the change scoped to a single news markdown file

## Source
- official source: https://www.linkedin.com/posts/georgialifesciences_biotechnology-lifesciences-nih-activity-7450957006598991873-haQ7

## Validation
- [ ] Ran `./scripts/test-website.sh` (attempted via `mamba run -n website`, but it timed out in this environment)
- [ ] Ran `bundle exec jekyll build` (plain `bundle` was unavailable; `mamba run -n website ... jekyll build` also timed out in this environment)

## Notes
- No image was added for this post.
