### PR TITLE
feat: add PR website preview screenshots

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -21,6 +21,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  pull-requests: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -35,27 +36,130 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@086ffb1a2090c870a3f881cc91ea83aa4243d408 # v1.195.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 1 # Increment this number if you need to re-download cached gems
+
+      - name: Setup Node
+        if: github.event_name == 'pull_request'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Detect changed newsroom post
+        if: github.event_name == 'pull_request'
+        id: changed_news_post
+        shell: bash
+        run: |
+          set -euo pipefail
+          post_path="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" | grep -E '^_posts/news/.*\.(md|markdown)$' | head -n1 || true)"
+          if [ -n "$post_path" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "post_path=$post_path" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Node dependencies
+        if: github.event_name == 'pull_request'
+        run: npm ci
+
+      - name: Run unit tests
+        if: github.event_name == 'pull_request'
+        run: npm run test:unit
+
+      - name: Install Playwright Chromium
+        if: github.event_name == 'pull_request' && steps.changed_news_post.outputs.found == 'true'
+        run: npx playwright install --with-deps chromium
+
       - name: Setup Pages
         if: github.event_name != 'pull_request'
         id: pages
         uses: actions/configure-pages@v4
+
       - name: Build with Jekyll for PR validation
         if: github.event_name == 'pull_request'
         run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
+
+      - name: Generate PR website previews
+        if: github.event_name == 'pull_request' && steps.changed_news_post.outputs.found == 'true'
+        run: npm run pr:previews -- --post-source "${{ steps.changed_news_post.outputs.post_path }}"
+
+      - name: Upload PR website previews
+        if: github.event_name == 'pull_request' && steps.changed_news_post.outputs.found == 'true'
+        id: upload_previews
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-website-previews-${{ github.event.pull_request.number }}
+          path: pr-previews/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Comment PR with preview artifact
+        if: github.event_name == 'pull_request' && steps.changed_news_post.outputs.found == 'true'
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_URL: ${{ steps.upload_previews.outputs.artifact-url }}
+          MANIFEST_PATH: pr-previews/manifest.json
+        with:
+          script: |
+            const fs = require('node:fs');
+            const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_PATH, 'utf8'));
+            const marker = '<!-- pr-website-previews -->';
+            const artifactUrl = process.env.ARTIFACT_URL;
+            const body = [
+              marker,
+              '## Website previews',
+              '',
+              `Generated visual previews for \`${manifest.postSourcePath}\`.`,
+              '',
+              artifactUrl ? `- Download artifact: [${artifactUrl}](${artifactUrl})` : '- Artifact uploaded in this workflow run.',
+              ...manifest.screenshots.map((shot) => `- ${shot.label}: \`${shot.screenshotPath}\``),
+              '',
+              '_Includes full-page screenshots for the front page, newsroom landing page, and the changed news post._',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
       - name: Build with Jekyll for Pages
         if: github.event_name != 'pull_request'
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+
       - name: Upload artifact
         if: github.event_name != 'pull_request'
         # Automatically uploads an artifact from the './_site' directory by default

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -57,10 +57,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          post_path="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" | grep -E '^_posts/news/.*\.(md|markdown)$' | head -n1 || true)"
-          if [ -n "$post_path" ]; then
+          mapfile -t post_paths < <(
+            git diff --name-status --diff-filter=AMRC "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" \
+              | awk 'NF {print $NF}' \
+              | grep -E '^_posts/news/.*\.(md|markdown)$' || true
+          )
+
+          echo "count=${#post_paths[@]}" >> "$GITHUB_OUTPUT"
+
+          if [ "${#post_paths[@]}" -eq 1 ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "post_path=$post_path" >> "$GITHUB_OUTPUT"
+            echo "post_path=${post_paths[0]}" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules/
 test-results/
 playwright-report/
 snapshots/
+pr-previews/
 
 # System files
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
   "scripts": {
     "build": "bundle exec jekyll build",
     "serve": "bundle exec jekyll serve --livereload",
-    "test": "npm run build && npx playwright test",
+    "test": "npm run test:unit && npm run build && npx playwright test",
+    "test:unit": "node --test scripts/__tests__/*.test.js",
     "test:update": "npm run build && npx playwright test --update-snapshots",
     "snapshots": "npm run build && node scripts/snapshot-site.js",
     "snapshots:only": "node scripts/snapshot-site.js",
+    "pr:previews": "node scripts/capture-pr-previews.js",
     "playwright:install": "npx playwright install"
   },
   "repository": {

--- a/scripts/__tests__/capture-pr-previews.test.js
+++ b/scripts/__tests__/capture-pr-previews.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const {
   buildPreviewPlan,
   getChangedNewsPostPaths,
+  getPreviewableNewsPostPaths,
 } = require('../capture-pr-previews');
 
 function write(filePath, content) {
@@ -26,6 +27,23 @@ test('getChangedNewsPostPaths keeps only markdown news posts', () => {
     [
       '_posts/news/2026-04-21-feature.md',
       '_posts/news/2026-04-22-followup.markdown',
+    ]
+  );
+});
+
+test('getPreviewableNewsPostPaths ignores deleted news posts and preserves modified ones', () => {
+  assert.deepEqual(
+    getPreviewableNewsPostPaths([
+      'M\t_posts/news/2026-04-21-feature.md',
+      'D\t_posts/news/2026-04-20-old-post.md',
+      'R100\t_posts/news/2026-04-19-before.md\t_posts/news/2026-04-19-after.md',
+      'A\t_posts/news/2026-04-22-new-post.markdown',
+      'M\tpages/news.md',
+    ]),
+    [
+      '_posts/news/2026-04-21-feature.md',
+      '_posts/news/2026-04-19-after.md',
+      '_posts/news/2026-04-22-new-post.markdown',
     ]
   );
 });
@@ -82,4 +100,33 @@ test('buildPreviewPlan resolves homepage, newsroom, and changed post output path
       },
     ]
   );
+});
+
+test('buildPreviewPlan derives the post output path from categories and slug instead of title matching', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'annate-pr-preview-dupes-'));
+  const postSourcePath = path.join(repoRoot, '_posts/news/2026-04-21-feature.md');
+
+  write(
+    postSourcePath,
+    `---\ntitle: "Shared Title"\ndate: "2026-04-21"\ncategories:\n- press-release\n- events\n---\n\nBody copy.\n`
+  );
+
+  write(path.join(repoRoot, '_site/index.html'), '<html><body><h1>Home</h1></body></html>');
+  write(path.join(repoRoot, '_site/news/index.html'), '<html><body><h1>News</h1></body></html>');
+  write(
+    path.join(repoRoot, '_site/aaa-wrong/index.html'),
+    '<html><head><title>Shared Title</title></head><body><h1>Shared Title</h1></body></html>'
+  );
+  write(
+    path.join(repoRoot, '_site/press-release/events/feature/index.html'),
+    '<html><head><title>Shared Title</title></head><body><h1>Shared Title</h1></body></html>'
+  );
+
+  const plan = buildPreviewPlan({ repoRoot, postSourcePath });
+
+  assert.equal(
+    path.relative(repoRoot, plan.targets[2].htmlPath),
+    '_site/press-release/events/feature/index.html'
+  );
+  assert.equal(plan.targets[2].routePath, '/press-release/events/feature/');
 });

--- a/scripts/__tests__/capture-pr-previews.test.js
+++ b/scripts/__tests__/capture-pr-previews.test.js
@@ -1,0 +1,85 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  buildPreviewPlan,
+  getChangedNewsPostPaths,
+} = require('../capture-pr-previews');
+
+function write(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+test('getChangedNewsPostPaths keeps only markdown news posts', () => {
+  assert.deepEqual(
+    getChangedNewsPostPaths([
+      '_posts/news/2026-04-21-feature.md',
+      '_posts/news/notes.txt',
+      'pages/news.md',
+      '_posts/events/2026-04-21-feature.md',
+      '_posts/news/2026-04-22-followup.markdown',
+    ]),
+    [
+      '_posts/news/2026-04-21-feature.md',
+      '_posts/news/2026-04-22-followup.markdown',
+    ]
+  );
+});
+
+test('buildPreviewPlan resolves homepage, newsroom, and changed post output paths', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'annate-pr-preview-'));
+
+  const postSourcePath = path.join(repoRoot, '_posts/news/2026-04-21-feature.md');
+  write(
+    postSourcePath,
+    `---\ntitle: "Preview Story"\ndate: "2026-04-21"\ncategories:\n- press-release\n---\n\nBody copy.\n`
+  );
+
+  write(path.join(repoRoot, '_site/index.html'), '<html><body><h1>Home</h1></body></html>');
+  write(path.join(repoRoot, '_site/news/index.html'), '<html><body><h1>News</h1></body></html>');
+  write(
+    path.join(repoRoot, '_site/press-release/feature/index.html'),
+    '<html><head><title>Preview Story</title></head><body><h1>Preview Story</h1></body></html>'
+  );
+
+  const plan = buildPreviewPlan({
+    repoRoot,
+    postSourcePath,
+    outputDir: path.join(repoRoot, 'pr-previews'),
+  });
+
+  assert.equal(plan.postSourcePath, postSourcePath);
+  assert.equal(plan.targets.length, 3);
+  assert.deepEqual(
+    plan.targets.map((target) => ({
+      name: target.name,
+      htmlPath: path.relative(repoRoot, target.htmlPath),
+      routePath: target.routePath,
+      screenshotPath: path.relative(repoRoot, target.screenshotPath),
+    })),
+    [
+      {
+        name: 'front-page',
+        htmlPath: '_site/index.html',
+        routePath: '/',
+        screenshotPath: 'pr-previews/front-page.png',
+      },
+      {
+        name: 'news-page',
+        htmlPath: '_site/news/index.html',
+        routePath: '/news/',
+        screenshotPath: 'pr-previews/news-page.png',
+      },
+      {
+        name: 'post-page',
+        htmlPath: '_site/press-release/feature/index.html',
+        routePath: '/press-release/feature/',
+        screenshotPath: 'pr-previews/post-page.png',
+      },
+    ]
+  );
+});

--- a/scripts/capture-pr-previews.js
+++ b/scripts/capture-pr-previews.js
@@ -76,9 +76,30 @@ function getChangedNewsPostPaths(paths) {
   return paths.filter((filePath) => /^_posts\/news\/.*\.(md|markdown)$/i.test(filePath));
 }
 
+function parseNameStatusLine(line) {
+  const fields = line.split('\t').filter(Boolean);
+  if (fields.length < 2) {
+    return null;
+  }
+
+  return {
+    status: fields[0],
+    path: fields[fields.length - 1],
+  };
+}
+
+function getPreviewableNewsPostPaths(lines) {
+  return lines
+    .map(parseNameStatusLine)
+    .filter(Boolean)
+    .filter((entry) => /^(A|M|R\d*|C\d*)$/i.test(entry.status))
+    .map((entry) => entry.path)
+    .filter((filePath) => /^_posts\/news\/.*\.(md|markdown)$/i.test(filePath));
+}
+
 function getGitDiffPaths(repoRoot, baseRef) {
   const base = baseRef || 'origin/main...HEAD';
-  const result = spawnSync('git', ['diff', '--name-only', base], {
+  const result = spawnSync('git', ['diff', '--name-status', '--diff-filter=AMRC', base], {
     cwd: repoRoot,
     encoding: 'utf8',
   });
@@ -87,10 +108,12 @@ function getGitDiffPaths(repoRoot, baseRef) {
     throw new Error(`git diff failed: ${result.stderr || result.stdout}`.trim());
   }
 
-  return result.stdout
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean);
+  return getPreviewableNewsPostPaths(
+    result.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+  );
 }
 
 function findBuiltPostHtml(siteDir, title) {
@@ -108,6 +131,46 @@ function findBuiltPostHtml(siteDir, title) {
   }
 
   throw new Error(`Unable to find a built HTML page in ${siteDir} for post title "${title}"`);
+}
+
+function getPostSlug(postSourcePath) {
+  return path.basename(postSourcePath).replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/\.(md|markdown)$/i, '');
+}
+
+function normalizeRoutePath(routePath) {
+  const trimmed = `${routePath || '/'}`.trim();
+  if (!trimmed || trimmed === '/') {
+    return '/';
+  }
+
+  return `/${trimmed.replace(/^\/+|\/+$/g, '')}/`;
+}
+
+function getBuiltPostRoutePath(postSourcePath, frontMatter) {
+  if (frontMatter.permalink) {
+    return normalizeRoutePath(frontMatter.permalink);
+  }
+
+  const categories = Array.isArray(frontMatter.categories)
+    ? frontMatter.categories
+    : frontMatter.categories
+      ? [frontMatter.categories]
+      : [];
+  return normalizeRoutePath([...categories, getPostSlug(postSourcePath)].join('/'));
+}
+
+function resolveBuiltPostHtmlPath(siteDir, postSourcePath, frontMatter) {
+  const routePath = getBuiltPostRoutePath(postSourcePath, frontMatter);
+  const htmlPath = routePath === '/'
+    ? path.join(siteDir, 'index.html')
+    : path.join(siteDir, routePath.slice(1), 'index.html');
+
+  ensureFile(htmlPath, `Built post export for ${path.basename(postSourcePath)}`);
+
+  return {
+    htmlPath,
+    routePath,
+  };
 }
 
 function toRoutePath(siteDir, htmlPath) {
@@ -134,7 +197,7 @@ function buildPreviewPlan({ repoRoot, postSourcePath, outputDir }) {
     throw new Error(`Missing title in ${postSourcePath}`);
   }
 
-  const postHtmlPath = findBuiltPostHtml(siteDir, frontMatter.title);
+  const builtPost = resolveBuiltPostHtmlPath(siteDir, postSourcePath, frontMatter);
   const screenshotDir = outputDir || path.join(repoRoot, 'pr-previews');
 
   return {
@@ -161,8 +224,8 @@ function buildPreviewPlan({ repoRoot, postSourcePath, outputDir }) {
       {
         name: 'post-page',
         label: frontMatter.title,
-        htmlPath: postHtmlPath,
-        routePath: toRoutePath(siteDir, postHtmlPath),
+        htmlPath: builtPost.htmlPath,
+        routePath: builtPost.routePath,
         screenshotPath: path.join(screenshotDir, 'post-page.png'),
       },
     ],
@@ -354,5 +417,6 @@ module.exports = {
   buildPreviewPlan,
   findBuiltPostHtml,
   getChangedNewsPostPaths,
+  getPreviewableNewsPostPaths,
   readFrontMatter,
 };

--- a/scripts/capture-pr-previews.js
+++ b/scripts/capture-pr-previews.js
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const { spawnSync } = require('node:child_process');
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function ensureFile(filePath, description) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`${description} not found at ${filePath}`);
+  }
+}
+
+function readFrontMatter(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const match = raw.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) {
+    throw new Error(`Missing YAML front matter in ${filePath}`);
+  }
+
+  const data = {};
+  let currentKey = null;
+
+  for (const line of match[1].split('\n')) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    const keyMatch = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (keyMatch) {
+      currentKey = keyMatch[1];
+      const rawValue = keyMatch[2].trim();
+      if (!rawValue) {
+        data[currentKey] = [];
+      } else {
+        data[currentKey] = rawValue.replace(/^['"]|['"]$/g, '');
+      }
+      continue;
+    }
+
+    const listMatch = line.match(/^\s*-\s*(.*)$/);
+    if (listMatch && currentKey) {
+      if (!Array.isArray(data[currentKey])) {
+        data[currentKey] = [];
+      }
+      data[currentKey].push(listMatch[1].trim().replace(/^['"]|['"]$/g, ''));
+    }
+  }
+
+  return data;
+}
+
+function listHtmlFiles(dir, prefix = '') {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const fullPath = path.join(dir, entry.name);
+    const relPath = path.join(prefix, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...listHtmlFiles(fullPath, relPath));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(relPath);
+    }
+  }
+
+  return files.sort();
+}
+
+function getChangedNewsPostPaths(paths) {
+  return paths.filter((filePath) => /^_posts\/news\/.*\.(md|markdown)$/i.test(filePath));
+}
+
+function getGitDiffPaths(repoRoot, baseRef) {
+  const base = baseRef || 'origin/main...HEAD';
+  const result = spawnSync('git', ['diff', '--name-only', base], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`git diff failed: ${result.stderr || result.stdout}`.trim());
+  }
+
+  return result.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function findBuiltPostHtml(siteDir, title) {
+  const files = listHtmlFiles(siteDir);
+  const titlePattern = new RegExp(`<title[^>]*>\\s*${escapeRegExp(title)}\\s*</title>`, 'i');
+  const h1Pattern = new RegExp(`<h1[^>]*>\\s*${escapeRegExp(title)}\\s*</h1>`, 'i');
+  const ogTitlePattern = new RegExp(`property=["']og:title["'][^>]*content=["']${escapeRegExp(title)}["']`, 'i');
+
+  for (const relPath of files) {
+    const absPath = path.join(siteDir, relPath);
+    const html = fs.readFileSync(absPath, 'utf8');
+    if (titlePattern.test(html) || h1Pattern.test(html) || ogTitlePattern.test(html)) {
+      return absPath;
+    }
+  }
+
+  throw new Error(`Unable to find a built HTML page in ${siteDir} for post title "${title}"`);
+}
+
+function toRoutePath(siteDir, htmlPath) {
+  const relativePath = path.relative(siteDir, htmlPath).split(path.sep).join('/');
+  if (relativePath === 'index.html') {
+    return '/';
+  }
+
+  if (relativePath.endsWith('/index.html')) {
+    return `/${relativePath.slice(0, -'index.html'.length)}`;
+  }
+
+  return `/${relativePath.replace(/\.html$/i, '')}`;
+}
+
+function buildPreviewPlan({ repoRoot, postSourcePath, outputDir }) {
+  const siteDir = path.join(repoRoot, '_site');
+  ensureFile(path.join(siteDir, 'index.html'), 'Front page export');
+  ensureFile(path.join(siteDir, 'news', 'index.html'), 'News page export');
+  ensureFile(postSourcePath, 'News post source');
+
+  const frontMatter = readFrontMatter(postSourcePath);
+  if (!frontMatter.title) {
+    throw new Error(`Missing title in ${postSourcePath}`);
+  }
+
+  const postHtmlPath = findBuiltPostHtml(siteDir, frontMatter.title);
+  const screenshotDir = outputDir || path.join(repoRoot, 'pr-previews');
+
+  return {
+    repoRoot,
+    siteDir,
+    postSourcePath,
+    postTitle: frontMatter.title,
+    screenshotDir,
+    targets: [
+      {
+        name: 'front-page',
+        label: 'Front page',
+        htmlPath: path.join(siteDir, 'index.html'),
+        routePath: toRoutePath(siteDir, path.join(siteDir, 'index.html')),
+        screenshotPath: path.join(screenshotDir, 'front-page.png'),
+      },
+      {
+        name: 'news-page',
+        label: 'News page',
+        htmlPath: path.join(siteDir, 'news', 'index.html'),
+        routePath: toRoutePath(siteDir, path.join(siteDir, 'news', 'index.html')),
+        screenshotPath: path.join(screenshotDir, 'news-page.png'),
+      },
+      {
+        name: 'post-page',
+        label: frontMatter.title,
+        htmlPath: postHtmlPath,
+        routePath: toRoutePath(siteDir, postHtmlPath),
+        screenshotPath: path.join(screenshotDir, 'post-page.png'),
+      },
+    ],
+  };
+}
+
+function writeManifest(plan) {
+  fs.mkdirSync(plan.screenshotDir, { recursive: true });
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    postSourcePath: path.relative(plan.repoRoot, plan.postSourcePath),
+    postTitle: plan.postTitle,
+    screenshots: plan.targets.map((target) => ({
+      name: target.name,
+      label: target.label,
+      htmlPath: path.relative(plan.repoRoot, target.htmlPath),
+      routePath: target.routePath,
+      screenshotPath: path.relative(plan.repoRoot, target.screenshotPath),
+    })),
+  };
+
+  fs.writeFileSync(path.join(plan.screenshotDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  fs.writeFileSync(
+    path.join(plan.screenshotDir, 'README.md'),
+    [
+      '# PR website previews',
+      '',
+      `Generated for: \`${manifest.postSourcePath}\``,
+      '',
+      ...manifest.screenshots.map((shot) => `- **${shot.label}** — \`${shot.screenshotPath}\``),
+      '',
+    ].join('\n')
+  );
+}
+
+function getContentType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return (
+    {
+      '.css': 'text/css; charset=utf-8',
+      '.gif': 'image/gif',
+      '.html': 'text/html; charset=utf-8',
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.js': 'application/javascript; charset=utf-8',
+      '.json': 'application/json; charset=utf-8',
+      '.png': 'image/png',
+      '.svg': 'image/svg+xml',
+      '.txt': 'text/plain; charset=utf-8',
+      '.webp': 'image/webp',
+      '.woff': 'font/woff',
+      '.woff2': 'font/woff2',
+      '.xml': 'application/xml; charset=utf-8',
+    }[ext] || 'application/octet-stream'
+  );
+}
+
+function createSiteServer(siteDir) {
+  const server = http.createServer((request, response) => {
+    const pathname = decodeURIComponent((request.url || '/').split('?')[0]);
+    const relativePath = pathname === '/'
+      ? 'index.html'
+      : pathname.endsWith('/')
+        ? `${pathname.slice(1)}index.html`
+        : pathname.slice(1);
+    const normalized = path.normalize(relativePath).replace(/^([.][.][/\\])+/, '');
+    let filePath = path.join(siteDir, normalized);
+
+    if (!filePath.startsWith(siteDir)) {
+      response.writeHead(403);
+      response.end('Forbidden');
+      return;
+    }
+
+    if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
+      filePath = path.join(filePath, 'index.html');
+    }
+
+    if (!fs.existsSync(filePath)) {
+      response.writeHead(404);
+      response.end('Not found');
+      return;
+    }
+
+    response.writeHead(200, { 'Content-Type': getContentType(filePath) });
+    response.end(fs.readFileSync(filePath));
+  });
+
+  return new Promise((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve({
+        close: () => new Promise((done, fail) => server.close((error) => (error ? fail(error) : done()))),
+        origin: `http://127.0.0.1:${address.port}`,
+      });
+    });
+  });
+}
+
+async function captureScreenshots(plan) {
+  const { chromium } = require('@playwright/test');
+
+  fs.mkdirSync(plan.screenshotDir, { recursive: true });
+  const browser = await chromium.launch({ headless: true });
+  const siteServer = await createSiteServer(plan.siteDir);
+
+  try {
+    const context = await browser.newContext({
+      viewport: { width: 1600, height: 1200 },
+      deviceScaleFactor: 1,
+    });
+
+    for (const target of plan.targets) {
+      const page = await context.newPage();
+      await page.goto(`${siteServer.origin}${target.routePath}`, { waitUntil: 'networkidle' });
+      const declineConsent = page.locator('[data-consent-decline]');
+      if (await declineConsent.count()) {
+        await declineConsent.first().click().catch(() => {});
+      }
+      await page.waitForTimeout(150);
+      await page.screenshot({ path: target.screenshotPath, fullPage: true });
+      await page.close();
+      console.log(`✓ ${target.name} -> ${path.relative(plan.repoRoot, target.screenshotPath)}`);
+    }
+
+    await context.close();
+  } finally {
+    await Promise.allSettled([siteServer.close(), browser.close()]);
+  }
+}
+
+function parseArgs(argv) {
+  const args = {
+    repoRoot: process.cwd(),
+    outputDir: null,
+    postSourcePath: null,
+    baseRef: null,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--repo-root') args.repoRoot = path.resolve(argv[++i]);
+    else if (arg === '--output-dir') args.outputDir = path.resolve(args.repoRoot, argv[++i]);
+    else if (arg === '--post-source') args.postSourcePath = path.resolve(args.repoRoot, argv[++i]);
+    else if (arg === '--base-ref') args.baseRef = argv[++i];
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = path.resolve(args.repoRoot);
+  const changedPostPaths = args.postSourcePath
+    ? [path.relative(repoRoot, args.postSourcePath)]
+    : getChangedNewsPostPaths(getGitDiffPaths(repoRoot, args.baseRef));
+
+  if (changedPostPaths.length === 0) {
+    throw new Error('No changed news post found. Pass --post-source _posts/news/<file>.md or update a newsroom post in this branch.');
+  }
+
+  if (changedPostPaths.length > 1) {
+    throw new Error(`Expected exactly one changed news post, found ${changedPostPaths.length}: ${changedPostPaths.join(', ')}`);
+  }
+
+  const postSourcePath = path.resolve(repoRoot, changedPostPaths[0]);
+  const plan = buildPreviewPlan({
+    repoRoot,
+    postSourcePath,
+    outputDir: args.outputDir || path.join(repoRoot, 'pr-previews'),
+  });
+
+  await captureScreenshots(plan);
+  writeManifest(plan);
+  console.log(`Saved PR previews to ${path.relative(repoRoot, plan.screenshotDir)}`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildPreviewPlan,
+  findBuiltPostHtml,
+  getChangedNewsPostPaths,
+  readFrontMatter,
+};

--- a/scripts/test-website.sh
+++ b/scripts/test-website.sh
@@ -26,6 +26,7 @@ export PLAYWRIGHT_BROWSERS_PATH=/tmp/website-playwright
 
 mkdir -p "$HOME" "$BUNDLE_PATH" "$PLAYWRIGHT_BROWSERS_PATH"
 
+npm run test:unit
 ruby -S bundle _2.4.1_ exec jekyll build
 npx playwright test
 '


### PR DESCRIPTION
## Summary
- add a preview capture script that exports full-page screenshots for the homepage, newsroom page, and the changed newsroom post
- update the PR workflow to build the site, upload the preview screenshots as an artifact, and post a sticky PR comment with the artifact link
- add a small unit test suite plus local test script coverage for the preview planning logic

## Validation
- [x] `npm run test:unit`
- [x] `bash ./scripts/test-website.sh`
- [x] `npm run pr:previews -- --post-source _posts/news/2026-04-21-gls-csba-fly-in.md`

## Notes
- preview generation only runs when exactly one `_posts/news/*.md` file changes in the PR
- screenshots are captured through a temporary local HTTP server so site assets render correctly
- the PR comment links to the uploaded artifact because GitHub Actions artifacts are the stable built-in hosting path available in workflow context
