### PR TITLE
fix: correct grant award attribution in news post

### DIFF
--- a/_posts/news/2026-05-22-ims-riney-translational-research-grant.md
+++ b/_posts/news/2026-05-22-ims-riney-translational-research-grant.md
@@ -1,32 +1,33 @@
 ---
 layout: page
-title: "Annate Bitherapeutics Awarded IMS and Riney Foundation Translational Research Grant"
+title: "University of Georgia Hajduk Lab Awarded IMS and Riney Foundation Translational Research Grant"
 date: "2026-05-22"
 categories:
   - press-release
   - recognition
   - research
 tags:
-  - Annate Bitherapeutics
+  - University of Georgia
+  - Hajduk Lab
   - International Myeloma Society
   - Paula and Rodger Riney Foundation
   - multiple myeloma
   - translational research
-  - University of Georgia
+  - Annate Bitherapeutics
   - Eric DeJesus
 header: no
-teaser: "Annate Bitherapeutics has been awarded a $250,000 International Myeloma Society and Paula and Rodger Riney Foundation Translational Research Grant to support its multiple myeloma program."
+teaser: "The University of Georgia’s Hajduk Lab has been awarded a $250,000 International Myeloma Society and Paula and Rodger Riney Foundation Translational Research Grant supporting multiple myeloma research connected to Annate’s platform."
 ---
 
-Annate Bitherapeutics is proud to share that its work has been awarded a **$250,000 International Myeloma Society (IMS) and Paula and Rodger Riney Foundation Translational Research Grant** to support the company’s **multiple myeloma program**. <!--more-->
+The **University of Georgia’s Hajduk Lab** has been awarded a **$250,000 International Myeloma Society (IMS) and Paula and Rodger Riney Foundation Translational Research Grant** supporting translational research in **multiple myeloma** connected to Annate Bitherapeutics’ platform. <!--more-->
 
-The award will support Annate’s academic laboratory at **The University of Georgia** for the continued translational development of its targeted biologic platform for multiple myeloma. According to Annate co-founder and CEO **Eric DeJesus, PhD**, the supported studies will focus on efficacy, mechanism, and combination strategies relevant to relapsed and refractory disease.
+The award will support work in the Hajduk Lab at the **University of Georgia** for the continued translational development of a targeted biologic platform for multiple myeloma. According to Annate co-founder and CEO **Eric DeJesus, PhD**, the supported studies will focus on efficacy, mechanism, and combination strategies relevant to relapsed and refractory disease.
 
 The IMS and Paula and Rodger Riney Foundation Translational Research Award supports investigator-initiated translational research in plasma cell disorders, including multiple myeloma. IMS describes the program as supporting research intended to advance prevention, early detection, diagnosis, and treatment of plasma cell disorders.
 
-Dr. DeJesus noted that the support from IMS and the Paula and Rodger Riney Foundation represents an important step as Annate continues building the translational data package needed to further de-risk and advance its platform.
+Dr. DeJesus noted that the support from IMS and the Paula and Rodger Riney Foundation represents an important step in building the translational data package needed to further de-risk and advance the platform.
 
-Annate is grateful to IMS, the Paula and Rodger Riney Foundation, and the collaborators and advisors supporting the company’s multiple myeloma program, including **Drs. Ajay Nooka and Vikas Gupta**, advisor **Dr. Gregory Lesinski**, **Winship Cancer Institute of Emory University**, and the **University of Georgia Innovation District**.
+Annate is grateful to IMS, the Paula and Rodger Riney Foundation, and the collaborators and advisors supporting this multiple myeloma research, including **Drs. Ajay Nooka and Vikas Gupta**, advisor **Dr. Gregory Lesinski**, **Winship Cancer Institute of Emory University**, and the **University of Georgia Innovation District**.
 
 Read more:
 [Eric DeJesus, PhD on LinkedIn](https://www.linkedin.com/posts/eric-dejesus-phd-77b710225_i-am-honored-and-excited-to-share-that-our-activity-7463427835333050368-r8A9)


### PR DESCRIPTION
## Summary
- Updates the May 22 IMS/Riney grant news post to attribute the award to the University of Georgia's Hajduk Lab
- Removes wording that implied Annate Bitherapeutics was awarded the grant
- Keeps Annate relevance limited to the connected platform and collaborators

## Test Plan
- HOME=/home/mcipriano bash ./scripts/test-website.sh